### PR TITLE
Try and use a similar import order

### DIFF
--- a/ide-style/intellij/sofi-intellij-code-style.xml
+++ b/ide-style/intellij/sofi-intellij-code-style.xml
@@ -23,6 +23,20 @@
       <emptyLine />
       <package name="com.sofi" withSubpackages="true" static="false" />
       <emptyLine />
+      <package name="configs" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="controllers" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="exceptions" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="models" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="services" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="views" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="play" withSubpackages="true" static="false" />
+      <emptyLine />
       <package name="" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="java" withSubpackages="true" static="false" />


### PR DESCRIPTION
https://sofiinc.atlassian.net/wiki/spaces/~mconroy/blog/2015/03/05/44400887/Eclipse+Import+Ordering
I'm not sure if we're still sticking to this import order, but it's
being referenced in pull requests, and I don't want to waste time ordering imports, when the IDE has essentially taken away any responsibility I have of looking at them ;)